### PR TITLE
[#AV-163] Bugfix : Query 수행 후 GraphFrame에서 오류 발생

### DIFF
--- a/frontend/src/components/sidebar/presentations/SidebarHome.jsx
+++ b/frontend/src/components/sidebar/presentations/SidebarHome.jsx
@@ -148,15 +148,7 @@ const ConnectedText =({userName, roleName}) => (
 
 const DBMSText =({dbname, graph}) => (
     <div>
-        <h6>
-            <div style={{display: 'flex', flexWrap: 'wrap'}}>      
-                <SubLabelRight label="Version :" classes="col-sm-6"></SubLabelRight>
-                <SubLabelLeft label="-" classes="col-sm-6"></SubLabelLeft>
-            </div>
-            <div style={{display: 'flex', flexWrap: 'wrap'}}>      
-                <SubLabelRight label="Edition :" classes="col-sm-6"></SubLabelRight>
-                <SubLabelLeft label="-" classes="col-sm-6"></SubLabelLeft>
-            </div>
+        <h6>            
             <div style={{display: 'flex', flexWrap: 'wrap'}}>      
                 <SubLabelRight label="Databases :" classes="col-sm-6"></SubLabelRight>
                 <SubLabelLeft label={dbname} classes="col-sm-6"></SubLabelLeft>

--- a/frontend/src/features/cypher/CypherUtil.js
+++ b/frontend/src/features/cypher/CypherUtil.js
@@ -254,6 +254,7 @@ const generateElements = (nodeLegend, edgeLegend, nodes, edges, alias, val, isNe
     if (val['start'] && val['end']) {
         if (!edgeLegend.hasOwnProperty(labelName)) { edgeLegend[labelName] = Object.assign({ size: getEdgeSize(labelName), caption: getCaption('edge', val) }, getEdgeColor(labelName)) }
         if (!edgelabelCaptions.hasOwnProperty(labelName)) { edgelabelCaptions[labelName] = 'label' }
+        if (!val.properties.hasOwnProperty(edgeLegend.caption)) { edgeLegend[labelName].caption = getCaption('edge', val) }
         edges.push(
             {
                 group: 'edges'
@@ -276,6 +277,7 @@ const generateElements = (nodeLegend, edgeLegend, nodes, edges, alias, val, isNe
     } else {
         if (!nodeLegend.hasOwnProperty(labelName)) { nodeLegend[labelName] = Object.assign({ size: getNodeSize(labelName), caption: getCaption('node', val) }, getNodeColor(labelName)) }
         if (!nodelabelCaptions.hasOwnProperty(labelName)) { nodelabelCaptions[labelName] = 'gid' }
+        if (!val.properties.hasOwnProperty(nodeLegend.caption)) { nodeLegend[labelName].caption = getCaption('node', val) }
         nodes.push(
             {
                 group: 'nodes'


### PR DESCRIPTION
쿼리 수행후 GraphFrame 에서 오류 발생하는 현상 수정하였습니다.
쿼리를 수행하여 생기는 node 들의 properties 에 'name' 이 있는 경우 nodeLegend 의 caption 값을 'name'  으로 설정하게 되는데
질의 된 결과로 반환된 node들 중  properties  에 'name' 이 없는경우 에러가 발생하는 현상으로 확인되어 수정 진행하였습니다. 

